### PR TITLE
Add attack plan and drop ZIP packaging requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Je negeert alles dat buiten het hier gedefinieerde IO-contract valt.
 
     `Catid, title_selected, concept_notes, primitives_used, path_hash, width, height, stroke_width, color_hex, validation_passed, source_icon`.  
 
-- **Packaging:** 1 CSV met alle SVG’s + manifest in folder "output"
+- **Packaging:** Verzameling in map "output" met alle SVG's en manifest (geen ZIP)
  
 ---
  
@@ -113,9 +113,9 @@ Je negeert alles dat buiten het hier gedefinieerde IO-contract valt.
  
 # Output
 
-- Per CSV: een **zip** met alle `{Catid}.svg` + `manifest.csv`.  
+- Per CSV: een map `output` met alle `{Catid}.svg` + `manifest.csv`.
 
-- Geen extra tekst, geen JSON.  
+- Geen extra tekst, geen JSON.
  
 ---
  

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Catid, Root category, Sub category, Sub-sub category, Sub-sub-sub category, Sub-
   Catid, title_selected, concept_notes, primitives_used, path_hash, width, height, stroke_width, color_hex, validation_passed, source_icon
   ```
 
-- Package results as a **ZIP**: all SVGs + `manifest.csv`.
+- Place results in an `output` directory containing all SVGs and `manifest.csv` (no ZIP).
 
 ---
 

--- a/actionlist.md
+++ b/actionlist.md
@@ -10,8 +10,9 @@
 - `primitives_used` is a comma-separated list of SVG primitives present in the final icon (`path`, `circle`, `rect`, `line`, `polyline`, `polygon`).
 - `path_hash` is the SHA-256 hash of the concatenated `d` attributes from all paths in the SVG.
 - When generating custom icons, ensure they communicate meaning with simple, recognizable shapes, using 2–6 primitives and the specified stroke style.
-- GitHub accepts `.svg` files but blocks files larger than 100 MiB; keep ZIP artifacts under this limit or plan for external storage if larger.
+- Output files are stored directly in an `output` directory; no ZIP packaging is required.
+- GitHub accepts `.svg` files but blocks files larger than 100 MiB; ensure individual files stay below this limit.
 - For web research, retrieve pages using `curl` with the `https://r.jina.ai/` prefix (or text-based tools like `lynx`) to access clean text for citation.
 
 ## Items Needing Clarification
-- Confirm whether a Google Drive or other external storage interface is required when ZIP packages approach GitHub's 100 MiB file limit.
+- Confirm whether an external storage solution (e.g., Google Drive) is required if repository artifacts approach GitHub's 100 MiB file limit.

--- a/plan2attack.md
+++ b/plan2attack.md
@@ -1,0 +1,40 @@
+# Plan to Generate One SVG per Category
+
+## Overview
+This document outlines the approach to ensure every category in the e-commerce taxonomy has exactly one deterministic SVG icon in house style. When no suitable icon exists, a new one will be generated consistent with existing icons.
+
+## Steps
+1. **Collect Categories**
+   - Parse input CSVs or `category_tree_report.xlsx` to obtain all `Catid` values and their most specific category names.
+   - Ensure each category is processed once.
+
+2. **Determine Search Query**
+   - For each row, identify the lowest non-empty category field.
+   - Translate Dutch terms to English when needed for search clarity.
+
+3. **Search SVGrepo**
+   - Use the selected category name as query on svgrepo.com.
+   - Prefer simple icons built from paths/lines/circles without text or decorative clutter.
+
+4. **Select or Generate Icon**
+   - **If a suitable SVGrepo icon exists:**
+     - Download and record its URL.
+     - Restyle it to match the repository specifications (stroke `#E63B14`, width `12`, round caps/joins, no fills, 256×256 viewBox, ≤6 primitives).
+   - **If no icon is found:**
+     - Generate an original icon seeded with `SHA256(Catid)` to guarantee determinism.
+     - Use 2–6 primitives that clearly convey the category concept and match the overall visual tone of existing icons.
+
+5. **Validation & Saving**
+   - Verify: correct viewBox, stroke attributes, no forbidden elements, ≤6 primitives, unique `path_hash` within batch.
+   - Save icon as `{Catid}.svg` in the `output` directory.
+   - Append a row to `manifest.csv` with required metadata including `source_icon` (`URL` or `generated`).
+
+6. **Consistency Check**
+   - After processing all categories, ensure there is exactly one SVG file per `Catid` and that every manifest entry references an existing file.
+
+7. **Updates & Logs**
+   - Maintain documentation (`README.md`, `AGENTS.md`, `actionlist.md`, `questions.md`) as processes evolve.
+   - Record any uncertainties or required clarifications in `questions.md`.
+
+## Result
+Following these steps will produce a fully populated `output` directory containing one validated SVG per category and a comprehensive `manifest.csv` for operator review.

--- a/questions.md
+++ b/questions.md
@@ -1,3 +1,3 @@
 # Questions
 
-1. If generated ZIP packages are expected to exceed GitHub's 100 MiB file limit, should we integrate an external storage solution (e.g., Google Drive), and what interface is required?
+1. If the repository's SVG outputs approach GitHub's 100 MiB file limit, should we integrate an external storage solution (e.g., Google Drive), and what interface is required?


### PR DESCRIPTION
## Summary
- Document step-by-step plan to produce one SVG per category
- Remove ZIP packaging requirement from AGENTS, README, and action list
- Clarify open question on external storage and update related docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e7a0a52c832483352f2ab3011c76