### PR TITLE
Add batch background update script for SVG icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ Catid, Root category, Sub category, Sub-sub category, Sub-sub-sub category, Sub-
 
 ## Output
 
-- For each CSV:  
-- One directory "output" containing all `{Catid}.svg` + `manifest.csv`.  
+- For each CSV:
+- One directory "output" containing all `{Catid}.svg` + `manifest.csv`.
 - No extra text, no JSON.
+
+---
+
+## Background Updates
+
+Icons are created with a transparent background. To apply or remove a solid background color across all SVGs later, use the helper script documented in [background_update_procedure.md](background_update_procedure.md).
 
 ---
 

--- a/background_update_procedure.md
+++ b/background_update_procedure.md
@@ -1,0 +1,21 @@
+# Batch Updating SVG Backgrounds
+
+This repository's icons use a transparent 256×256 canvas. If a customer later requests a specific background color or opacity, run the helper script to modify all SVGs in one go.
+
+## Usage
+
+```
+python scripts/update_background.py --color "#FFFFFF" --opacity 1.0 --input-dir output
+```
+
+- `--color` sets the background fill color.
+- `--opacity` (optional) specifies fill transparency between `0` (transparent) and `1` (opaque).
+- `--input-dir` points to the folder containing the SVG files. Defaults to `output`.
+
+To remove previously applied backgrounds and restore transparency:
+
+```
+python scripts/update_background.py --remove --input-dir output
+```
+
+The script adds or updates a `<rect id="background">` element at the start of each SVG to represent the background. Removing removes this rectangle entirely.

--- a/scripts/update_background.py
+++ b/scripts/update_background.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Batch update background color or transparency for SVG files."""
+
+import argparse
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def update_svg(path: Path, color: str | None, opacity: float | None) -> None:
+    """Update or remove the background rectangle in a single SVG file."""
+    tree = ET.parse(path)
+    root = tree.getroot()
+
+    # search for existing background rect
+    bg = None
+    for child in list(root):
+        if child.tag == "rect" and child.attrib.get("id") == "background":
+            bg = child
+            break
+
+    if color is None:
+        # remove existing background to restore transparency
+        if bg is not None:
+            root.remove(bg)
+    else:
+        if bg is None:
+            bg = ET.Element(
+                "rect",
+                {
+                    "id": "background",
+                    "x": "0",
+                    "y": "0",
+                    "width": "256",
+                    "height": "256",
+                },
+            )
+            root.insert(0, bg)
+        bg.set("fill", color)
+        if opacity is not None:
+            bg.set("fill-opacity", str(opacity))
+        elif "fill-opacity" in bg.attrib:
+            del bg.attrib["fill-opacity"]
+
+    tree.write(path, encoding="utf-8", xml_declaration=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--color",
+        help="Hex color for background, e.g. #FFFFFF",
+    )
+    group.add_argument(
+        "--remove",
+        action="store_true",
+        help="Remove background rectangle to make SVG transparent",
+    )
+    parser.add_argument(
+        "--opacity",
+        type=float,
+        help="Optional fill opacity between 0 and 1",
+    )
+    parser.add_argument(
+        "--input-dir",
+        default="output",
+        help="Directory containing SVG files",
+    )
+    args = parser.parse_args()
+
+    color = None if args.remove else args.color
+    opacity = args.opacity if not args.remove else None
+
+    directory = Path(args.input_dir)
+    for svg_path in directory.glob("*.svg"):
+        update_svg(svg_path, color, opacity)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `update_background.py` for batch editing SVG background color or transparency
- document background update procedure and reference it in README

## Testing
- `python scripts/update_background.py --help`
- `python -m py_compile scripts/update_background.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7ecbb6bf083249b3ce4c4714bbd19