### PR TITLE
Add output validation script and report

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ To validate the output, run:
 python scripts/verify_icons.py output/test
 ```
 
+For a consolidated CSV report including basic semantic hints and duplicate
+geometry detection, run:
+
+```
+python scripts/validate_outputs.py output/test output/test2
+```
+
 ---
 
 ## Sanity Checklist

--- a/actionlist.md
+++ b/actionlist.md
@@ -16,6 +16,8 @@
 
 - Brand color palette and typography captured in style.md (primary #E63B14, secondary #004165, text #5E6A71, font Source Sans Pro).
 - `generate_icons.py` can create five style variants per category for test evaluation.
+- `validate_outputs.py` produces a consolidated CSV report with style checks,
+  duplicate-geometry detection and basic semantic hints.
 
 ## Items Needing Clarification
 - Confirm whether an external storage solution (e.g., Google Drive) is required if repository artifacts approach GitHub's 100 MiB file limit.

--- a/scripts/validate_outputs.py
+++ b/scripts/validate_outputs.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate SVG outputs for style and basic semantic hints.
+
+Usage:
+    python scripts/validate_outputs.py output/test output/test2
+
+The script scans each provided directory. If the directory directly
+contains a ``manifest.csv`` it will validate the icons in that folder.
+Otherwise each immediate subdirectory containing a ``manifest.csv`` is
+processed. A consolidated ``validation_report.csv`` is written to the
+current working directory.
+"""
+from __future__ import annotations
+
+import csv
+import hashlib
+import pathlib
+import re
+import sys
+from collections import defaultdict
+from typing import Dict, Iterable, List, Tuple
+
+STYLE = {
+    "stroke": "#E63B14",
+    "stroke-width": "12",
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+    "fill": "none",
+    "viewBox": "0 0 256 256",
+}
+
+FORBIDDEN_TAGS = {"style", "script", "defs", "mask", "clipPath"}
+FORBIDDEN_ATTRS = {"class", "style"}
+
+# Semantic hint keywords per token; extend as the taxonomy grows
+SEM_HINTS: Dict[str, List[str]] = {
+    "drill": ["drill", "tool", "bit"],
+    "screw": ["screw", "bolt", "nut"],
+    "laptop": ["laptop", "computer"],
+}
+
+SVG_TAG = re.compile(r"<svg[^>]*>", re.I)
+ATTR = lambda k: re.compile(rf"\b{k}=['\"]([^'\"]+)['\"]", re.I)
+CLEAN_TAG = re.compile(r"</?([a-zA-Z0-9:-]+)[^>]*>")
+
+
+def check_style(svg_text: str) -> Tuple[bool, List[str]]:
+    """Return (ok, errors) for style compliance."""
+    m = SVG_TAG.search(svg_text)
+    if not m:
+        return False, ["no <svg> tag"]
+    head = m.group(0)
+    errors: List[str] = []
+    vb_match = ATTR("viewBox").search(head)
+    if not vb_match or vb_match.group(1) != STYLE["viewBox"]:
+        errors.append("bad viewBox")
+    for k, v in STYLE.items():
+        if k == "viewBox":
+            continue
+        if f"{k}='{v}'" not in svg_text and f"{k}=\"{v}\"" not in svg_text:
+            errors.append(f"missing/incorrect {k}")
+    for tag in FORBIDDEN_TAGS:
+        if re.search(rf"</?{tag}\b", svg_text, re.I):
+            errors.append(f"forbidden tag: {tag}")
+    for attr in FORBIDDEN_ATTRS:
+        if re.search(rf"\s{attr}=", svg_text, re.I):
+            errors.append(f"forbidden attr: {attr}")
+    return (not errors), errors
+
+
+def path_hash(svg_text: str) -> str:
+    """Compute a stable hash for geometry."""
+    norm = re.sub(r"(-?\d+\.\d{3})\d+", r"\1", svg_text)
+    return hashlib.sha256(norm.encode("utf-8")).hexdigest()[:16]
+
+
+def semantic_hint_ok(subject: str, svg_text: str):
+    tokens = re.findall(r"[a-z0-9]+", subject.lower())
+    for t in tokens:
+        for hint in SEM_HINTS.get(t, []):
+            if re.search(rf"\b{hint}\b", svg_text, re.I):
+                return True
+    return None  # unknown
+
+
+def load_manifest(p: pathlib.Path) -> Dict[str, Dict[str, str]]:
+    man: Dict[str, Dict[str, str]] = {}
+    mf = p / "manifest.csv"
+    if mf.exists():
+        with mf.open("r", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                man[row.get("Catid", "")] = row
+    return man
+
+
+def process_dir(base: pathlib.Path,
+                report: List[Dict[str, str]],
+                dup_hashes: defaultdict) -> None:
+    man = load_manifest(base)
+    for svg in base.glob("*.svg"):
+        catid = svg.stem
+        svg_text = svg.read_text("utf-8", errors="ignore")
+        ok_style, errs = check_style(svg_text)
+        ph = path_hash(svg_text)
+        dup_hashes[ph].append(str(svg))
+        subject = man.get(catid, {}).get("title_selected") or man.get(catid, {}).get("concept_notes") or ""
+        sem = semantic_hint_ok(subject, svg_text)
+        report.append({
+            "dir": str(base),
+            "catid": catid,
+            "subject": subject,
+            "style_ok": ok_style,
+            "style_errors": ";".join(errs),
+            "path_hash": ph,
+            "sem_match": {True: "PASS", False: "FAIL", None: "UNKNOWN"}[sem if sem is not None else None],
+            "source_icon": man.get(catid, {}).get("source_icon", ""),
+        })
+
+
+def iter_target_dirs(paths: Iterable[pathlib.Path]) -> Iterable[pathlib.Path]:
+    for root in paths:
+        if (root / "manifest.csv").exists():
+            yield root
+        else:
+            for child in sorted(root.iterdir()):
+                if child.is_dir() and (child / "manifest.csv").exists():
+                    yield child
+
+
+def main(argv: List[str]) -> None:
+    if not argv:
+        argv = ["output/test", "output/test2"]
+    bases = list(iter_target_dirs(map(pathlib.Path, argv)))
+    report: List[Dict[str, str]] = []
+    dup_hashes: defaultdict = defaultdict(list)
+    for base in bases:
+        process_dir(base, report, dup_hashes)
+    for h, files in dup_hashes.items():
+        if len(files) > 1:
+            print("DUPLICATE_GEOMETRY:", h, files)
+    if report:
+        with open("validation_report.csv", "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(report[0].keys()))
+            writer.writeheader()
+            writer.writerows(report)
+        print("Wrote validation_report.csv with", len(report), "rows")
+    else:
+        print("No icons processed")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/validation_report.csv
+++ b/validation_report.csv
@@ -1,0 +1,51 @@
+dir,catid,subject,style_ok,style_errors,path_hash,sem_match,source_icon
+output/test/blue,1005,Clothing,False,missing/incorrect stroke,93eeead76f719907,UNKNOWN,generated
+output/test/blue,1002,Furniture,False,missing/incorrect stroke,5e096ab25eb43dee,UNKNOWN,generated
+output/test/blue,1009,Garden,False,missing/incorrect stroke,27cf40473dcf2586,UNKNOWN,generated
+output/test/blue,1007,Beauty,False,missing/incorrect stroke,3845259b50e7a45a,UNKNOWN,generated
+output/test/blue,1003,Toys,False,missing/incorrect stroke,1f0a2b11b34a4456,UNKNOWN,generated
+output/test/blue,1001,Electronics,False,missing/incorrect stroke,19de665dd996a0fe,UNKNOWN,generated
+output/test/blue,1008,Automotive,False,missing/incorrect stroke,3aff8a85c7426d31,UNKNOWN,generated
+output/test/blue,1010,Kitchen,False,missing/incorrect stroke,658e37501f3c09b7,UNKNOWN,generated
+output/test/blue,1006,Sports,False,missing/incorrect stroke,5f56720af64f690c,UNKNOWN,generated
+output/test/blue,1004,Books,False,missing/incorrect stroke,2fdbac09b3917fc5,UNKNOWN,generated
+output/test/classic,1005,Clothing,True,,dd03786f987883f7,UNKNOWN,generated
+output/test/classic,1002,Furniture,True,,50ca284cb184a63c,UNKNOWN,generated
+output/test/classic,1009,Garden,True,,3769dab86352f8bc,UNKNOWN,generated
+output/test/classic,1007,Beauty,True,,c6debaf8950881df,UNKNOWN,generated
+output/test/classic,1003,Toys,True,,db1bfc6b05a606b3,UNKNOWN,generated
+output/test/classic,1001,Electronics,True,,3642f59919353707,UNKNOWN,generated
+output/test/classic,1008,Automotive,True,,31ffffb9757e49e0,UNKNOWN,generated
+output/test/classic,1010,Kitchen,True,,ed6d117a29829600,UNKNOWN,generated
+output/test/classic,1006,Sports,True,,2db48bbaab4fca37,UNKNOWN,generated
+output/test/classic,1004,Books,True,,5dea5c0b0b4c8a82,UNKNOWN,generated
+output/test/mono,1005,Clothing,False,missing/incorrect stroke,9307fa5d8e846e5a,UNKNOWN,generated
+output/test/mono,1002,Furniture,False,missing/incorrect stroke,2890ee57b01b5062,UNKNOWN,generated
+output/test/mono,1009,Garden,False,missing/incorrect stroke,fb2d5a59ed170282,UNKNOWN,generated
+output/test/mono,1007,Beauty,False,missing/incorrect stroke,8892fe7bb33a4dd9,UNKNOWN,generated
+output/test/mono,1003,Toys,False,missing/incorrect stroke,35fc9955c8106f3a,UNKNOWN,generated
+output/test/mono,1001,Electronics,False,missing/incorrect stroke,d7b67036cf3893f5,UNKNOWN,generated
+output/test/mono,1008,Automotive,False,missing/incorrect stroke,a1908695dec179eb,UNKNOWN,generated
+output/test/mono,1010,Kitchen,False,missing/incorrect stroke,e74ff3a3e57575d7,UNKNOWN,generated
+output/test/mono,1006,Sports,False,missing/incorrect stroke,598a1f4365cc9371,UNKNOWN,generated
+output/test/mono,1004,Books,False,missing/incorrect stroke,2863ef883e08b786,UNKNOWN,generated
+output/test/thick,1005,Clothing,False,missing/incorrect stroke-width,f92d8e403e60197f,UNKNOWN,generated
+output/test/thick,1002,Furniture,False,missing/incorrect stroke-width,098e84899966a636,UNKNOWN,generated
+output/test/thick,1009,Garden,False,missing/incorrect stroke-width,2b69b0430005054e,UNKNOWN,generated
+output/test/thick,1007,Beauty,False,missing/incorrect stroke-width,723fe17bf5f8527a,UNKNOWN,generated
+output/test/thick,1003,Toys,False,missing/incorrect stroke-width,9915ae2375a576da,UNKNOWN,generated
+output/test/thick,1001,Electronics,False,missing/incorrect stroke-width,bf2f3015f589bbf1,UNKNOWN,generated
+output/test/thick,1008,Automotive,False,missing/incorrect stroke-width,04a1ea913c4af1d4,UNKNOWN,generated
+output/test/thick,1010,Kitchen,False,missing/incorrect stroke-width,2860f8c78c209273,UNKNOWN,generated
+output/test/thick,1006,Sports,False,missing/incorrect stroke-width,f9c03613d69a7d76,UNKNOWN,generated
+output/test/thick,1004,Books,False,missing/incorrect stroke-width,35946e3f1d106e75,UNKNOWN,generated
+output/test/thin,1005,Clothing,False,missing/incorrect stroke-width,0586e83fbfcffd1d,UNKNOWN,generated
+output/test/thin,1002,Furniture,False,missing/incorrect stroke-width,a41fa2a6cb3bae15,UNKNOWN,generated
+output/test/thin,1009,Garden,False,missing/incorrect stroke-width,72dfdd09f52363ca,UNKNOWN,generated
+output/test/thin,1007,Beauty,False,missing/incorrect stroke-width,8f46c0e72533375a,UNKNOWN,generated
+output/test/thin,1003,Toys,False,missing/incorrect stroke-width,1fb62d12ae6245d6,UNKNOWN,generated
+output/test/thin,1001,Electronics,False,missing/incorrect stroke-width,18b52434946abf1f,UNKNOWN,generated
+output/test/thin,1008,Automotive,False,missing/incorrect stroke-width,f8ab88928bf5d218,UNKNOWN,generated
+output/test/thin,1010,Kitchen,False,missing/incorrect stroke-width,a9add04917a680c9,UNKNOWN,generated
+output/test/thin,1006,Sports,False,missing/incorrect stroke-width,1b87686b1d6a41c9,UNKNOWN,generated
+output/test/thin,1004,Books,False,missing/incorrect stroke-width,289c8832260b86ce,UNKNOWN,generated


### PR DESCRIPTION
## Summary
- add `validate_outputs.py` to audit SVG outputs for style, semantic hints, and duplicate geometry
- document new validation workflow in README and actionlist
- include current `validation_report.csv` from sample outputs

## Testing
- `python scripts/validate_outputs.py output/test output/test2`


------
https://chatgpt.com/codex/tasks/task_e_68c7f98d84a88324a635ff9cd050ff1e