### PR TITLE
Add raw QA variant to multi-style icon downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,13 @@ Icons are created with a transparent background. To apply or remove a solid back
 ## Test Run and Style Variants
 
 Use `scripts/generate_icons.py` to create sample icons for evaluation using the
-[svgapi.com](https://svgapi.com) catalogue. By default it outputs the "classic"
-brand style; provide `--styles` with a comma-separated list to render multiple
-variants in one run.
+[svgapi.com](https://svgapi.com) catalogue. By default the script now renders
+five variants per category: a raw download (`original`) saved as `test-*.svg`
+for operator checks, plus four styled exports (`brand`, `thin`, `thick`,
+`mono`). Provide `--styles` with a comma-separated list to customise the set.
 
 ```
-python scripts/generate_icons.py --csv categories_sample.csv --out output/test --styles classic
+python scripts/generate_icons.py --csv categories_sample.csv --out output/test
 ```
 
 The script writes a `generation.log` file inside the requested output folder so


### PR DESCRIPTION
## Summary
- update the SVG download pipeline to support a raw `test-` prefixed variant and four styled exports by default
- add helpers that parse source SVG dimensions so metadata and manifests reflect raw outputs
- document the new five-style default behaviour in the README usage section

## Testing
- python -m compileall scripts/generate_icons.py

------
https://chatgpt.com/codex/tasks/task_e_68c8932f9fc48324ac1237c0796895b2